### PR TITLE
Update integration devices

### DIFF
--- a/.github/workflows/ci-xcode-integration.yaml
+++ b/.github/workflows/ci-xcode-integration.yaml
@@ -18,8 +18,8 @@ jobs:
         xcode_version: ["15.4"]
         device:
           - "iPhone 15"
-          - "iPhone 14 Plus"
-          - "iPhone 14 Pro"
+          - "iPhone 15 Plus"
+          - "iPhone 15 Pro"
     steps:
       - name: Select Xcode
         # See https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md


### PR DESCRIPTION
## Checklist

GHA runner dropped iPhone 14s: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-simulators

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
