### PR TITLE
remove bootstatus for integration test

### DIFF
--- a/.github/workflows/ci-xcode-integration.yaml
+++ b/.github/workflows/ci-xcode-integration.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: Boot simulator
         run: |
           xcrun simctl boot "${{ matrix.device }}"
-          xcrun simctl bootstatus "${{ matrix.device }}"
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Checklist
Don't need to check for boot status on device, which can hang if Terminal is not being response
- [X] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
